### PR TITLE
Add first external only queue decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options
 - `--no-dedupe`: Do _not_ filter duplicate URLs (can result in a
   non-terminating process).
 - `--descendants-only`: Only crawl direct descendnats of the given URL
+- `--first-external-only`: Like descendants-only but check the statuscode of the first External URL
 - `--insecure`: Do not verify SSL certificates.
 - `--max-distance`: Maximum allowed distance from base URL (if not specified
   then there is no limitation).

--- a/lib/Command/CrawlCommand.php
+++ b/lib/Command/CrawlCommand.php
@@ -20,6 +20,7 @@ class CrawlCommand extends Command
 
     public const OPT_CONCURRENCY = 'concurrency';
     public const OPT_DESCENDANTS_ONLY = 'descendants-only';
+    public const OPT_FIRST_EXTERNAL_ONLY = 'first-external-only';
     public const OPT_MAX_DISTANCE = 'max-distance';
     public const OPT_NO_DEDUPE = 'no-dedupe';
 
@@ -54,6 +55,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_OUTPUT, 'o', InputOption::VALUE_REQUIRED, 'Output file');
         $this->addOption(self::OPT_NO_DEDUPE, 'D', InputOption::VALUE_NONE, 'Do not de-duplicate URLs');
         $this->addOption(self::OPT_DESCENDANTS_ONLY, 'l', InputOption::VALUE_NONE, 'Only crawl descendants of the given path');
+        $this->addOption(self::OPT_FIRST_EXTERNAL_ONLY, 'f', InputOption::VALUE_NONE, 'Only crawl the first external not its child');
         $this->addOption(self::OPT_INSECURE, 'k', InputOption::VALUE_NONE, 'Allow insecure server connections with SSL');
         $this->addOption(self::OPT_MAX_DISTANCE, 'm', InputOption::VALUE_REQUIRED, 'Maximum link distance from base URL');
         $this->addOption(self::OPT_LOAD_COOKIES, null, InputOption::VALUE_REQUIRED, 'Load cookies from file');
@@ -110,6 +112,7 @@ class CrawlCommand extends Command
         $outfile = $input->getOption(self::OPT_OUTPUT);
         $noDedupe = $this->castToBool($input->getOption(self::OPT_NO_DEDUPE));
         $descendantsOnly = $this->castToBool($input->getOption(self::OPT_DESCENDANTS_ONLY));
+        $firstExternalOnly = $this->castToBool($input->getOption(self::OPT_FIRST_EXTERNAL_ONLY));
         $insecure = $this->castToBool($input->getOption(self::OPT_INSECURE));
         $maxDistance = $input->getOption(self::OPT_MAX_DISTANCE);
         $cookieFile = $input->getOption(self::OPT_LOAD_COOKIES);
@@ -118,6 +121,7 @@ class CrawlCommand extends Command
         $builder->maxConcurrency($maxConcurrency);
         $builder->noDeduplication($noDedupe);
         $builder->descendantsOnly($descendantsOnly);
+        $builder->firstExternalOnly($firstExternalOnly);
         $builder->noPeerVerification($insecure);
         if ($outfile) {
             $builder->publishTo($this->castToString($outfile));

--- a/lib/Command/CrawlCommand.php
+++ b/lib/Command/CrawlCommand.php
@@ -55,7 +55,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_OUTPUT, 'o', InputOption::VALUE_REQUIRED, 'Output file');
         $this->addOption(self::OPT_NO_DEDUPE, 'D', InputOption::VALUE_NONE, 'Do not de-duplicate URLs');
         $this->addOption(self::OPT_DESCENDANTS_ONLY, 'l', InputOption::VALUE_NONE, 'Only crawl descendants of the given path');
-        $this->addOption(self::OPT_FIRST_EXTERNAL_ONLY, 'f', InputOption::VALUE_NONE, 'Only crawl the first external not its child');
+        $this->addOption(self::OPT_FIRST_EXTERNAL_ONLY, 'x', InputOption::VALUE_NONE, 'Only crawl the first external not its child');
         $this->addOption(self::OPT_INSECURE, 'k', InputOption::VALUE_NONE, 'Allow insecure server connections with SSL');
         $this->addOption(self::OPT_MAX_DISTANCE, 'm', InputOption::VALUE_REQUIRED, 'Maximum link distance from base URL');
         $this->addOption(self::OPT_LOAD_COOKIES, null, InputOption::VALUE_REQUIRED, 'Load cookies from file');

--- a/lib/Model/Crawler.php
+++ b/lib/Model/Crawler.php
@@ -43,7 +43,6 @@ class Crawler
         @$dom->loadHTML($body);
         $xpath = new DOMXPath($dom);
 
-        $linkUrls = [];
         foreach ($xpath->query('//a') as $linkElement) {
             $href = $linkElement->getAttribute('href');
 

--- a/lib/Model/DispatcherBuilder.php
+++ b/lib/Model/DispatcherBuilder.php
@@ -108,7 +108,7 @@ class DispatcherBuilder
 
     public function firstExternalOnly(bool $value = true): self
     {
-        $this->firstExternalONly = $value;
+        $this->firstExternalOnly = $value;
 
         return $this;
     }
@@ -181,7 +181,7 @@ class DispatcherBuilder
             $queue = new OnlyDescendantOrSelfQueue($queue, $this->baseUrl);
         }
 
-        if ($this->firstExternalONly) {
+        if ($this->firstExternalOnly) {
             $queue = new FirstExternalOnlyQueue($queue, $this->baseUrl);
         }
 

--- a/lib/Model/DispatcherBuilder.php
+++ b/lib/Model/DispatcherBuilder.php
@@ -14,6 +14,7 @@ use DTL\Extension\Fink\Model\Publisher\BlackholePublisher;
 use DTL\Extension\Fink\Model\Publisher\StreamPublisher;
 use DTL\Extension\Fink\Model\Queue\DedupeQueue;
 use DTL\Extension\Fink\Model\Queue\MaxDistanceQueue;
+use DTL\Extension\Fink\Model\Queue\FirstExternalOnlyQueue;
 use DTL\Extension\Fink\Model\Queue\OnlyDescendantOrSelfQueue;
 use DTL\Extension\Fink\Model\Queue\RealUrlQueue;
 use RuntimeException;
@@ -39,6 +40,11 @@ class DispatcherBuilder
      * @var bool
      */
     private $descendantsOnly;
+
+    /**
+     * @var bool
+     */
+    private $firstExternalONly;
 
     /**
      * @var string
@@ -96,6 +102,13 @@ class DispatcherBuilder
     public function descendantsOnly(bool $value = true): self
     {
         $this->descendantsOnly = $value;
+
+        return $this;
+    }
+
+    public function firstExternalOnly(bool $value = true): self
+    {
+        $this->firstExternalONly = $value;
 
         return $this;
     }
@@ -163,9 +176,13 @@ class DispatcherBuilder
         if (!$this->noDedupe) {
             $queue = new DedupeQueue($queue);
         }
-        
+
         if ($this->descendantsOnly) {
             $queue = new OnlyDescendantOrSelfQueue($queue, $this->baseUrl);
+        }
+
+        if ($this->firstExternalONly) {
+            $queue = new FirstExternalOnlyQueue($queue, $this->baseUrl);
         }
 
         if (null !== $this->maxDistance) {

--- a/lib/Model/DispatcherBuilder.php
+++ b/lib/Model/DispatcherBuilder.php
@@ -44,7 +44,7 @@ class DispatcherBuilder
     /**
      * @var bool
      */
-    private $firstExternalONly;
+    private $firstExternalOnly;
 
     /**
      * @var string

--- a/lib/Model/Queue/FirstExternalOnlyQueue.php
+++ b/lib/Model/Queue/FirstExternalOnlyQueue.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DTL\Extension\Fink\Model\Queue;
+
+use DTL\Extension\Fink\Model\Url;
+use DTL\Extension\Fink\Model\UrlQueue;
+
+class FirstExternalOnlyQueue implements UrlQueue
+{
+    /**
+     * @var UrlQueue
+     */
+    private $innerQueue;
+
+    /**
+     * @var Url
+     */
+    private $baseUrl;
+
+    public function __construct(UrlQueue $innerQueue, Url $baseUrl)
+    {
+        $this->innerQueue = $innerQueue;
+        $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        return $this->innerQueue->count();
+    }
+
+    public function enqueue(Url $url): void
+    {
+        if (!$referringUrl = $url->referrer()) {
+            // this is the "root" URL... nothing to do here
+            $this->innerQueue->enqueue($url);
+            return;
+        }
+
+        if (false === $referringUrl->equalsOrDescendantOf($this->baseUrl)) {
+            return;
+        }
+
+        $this->innerQueue->enqueue($url);
+    }
+
+    public function dequeue(): ?Url
+    {
+        return $this->innerQueue->dequeue();
+    }
+}

--- a/tests/EndToEnd/Command/CrawlCommandTest.php
+++ b/tests/EndToEnd/Command/CrawlCommandTest.php
@@ -26,6 +26,7 @@ class CrawlCommandTest extends EndToEndTestCase
 
         $rows = $this->parseResults($this->workspace()->path('/out.json'));
 
+        $this->assertCount(6, $rows);
         $this->assertStatus($rows, 200, 'blog.html');
         $this->assertStatus($rows, 200, 'about.html');
         $this->assertStatus($rows, 200, 'posts/post1.html');
@@ -46,10 +47,29 @@ class CrawlCommandTest extends EndToEndTestCase
 
         $rows = $this->parseResults($this->workspace()->path('/out.json'));
 
+        $this->assertCount(3, $rows);
         $this->assertUrlCount($rows, 0, 'blog.html');
         $this->assertUrlCount($rows, 0, 'about.html');
         $this->assertStatus($rows, 200, 'posts/post1.html');
         $this->assertStatus($rows, 200, 'posts/post2.html');
+    }
+
+    public function testCrawlsFirstExternalOnly()
+    {
+        $process = $this->execute([
+            'crawl',
+            self::EXAMPLE_URL . '/posts/external',
+            '--output='.$this->workspace()->path('/out.json'),
+            '--first-external-only'
+        ]);
+
+        $this->assertProcessSuccess($process);
+
+        $rows = $this->parseResults($this->workspace()->path('/out.json'));
+
+        $this->assertCount(2, $rows);
+        $this->assertStatus($rows, 200, 'posts');
+        $this->assertStatus($rows, 200, 'posts/external');
     }
 
     public function testAllowsUrlDuplication()

--- a/tests/Example/website/posts/external/index.html
+++ b/tests/Example/website/posts/external/index.html
@@ -1,0 +1,8 @@
+<html>
+    <body>
+        <h1>External</h1>
+        <ul>
+            <li><a href="/posts">Posts</a></li>
+        </ul>
+    </body>
+</html>

--- a/tests/Unit/Model/Queue/FirstExternalOnlyQueueTest.php
+++ b/tests/Unit/Model/Queue/FirstExternalOnlyQueueTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DTL\Extension\Fink\Tests\Unit\Model\Queue;
+
+use DTL\Extension\Fink\Model\Queue\FirstExternalOnlyQueue;
+use DTL\Extension\Fink\Model\Queue\RealUrlQueue;
+use DTL\Extension\Fink\Model\Url;
+use PHPUnit\Framework\TestCase;
+
+class FirstExternalOnlyQueueTest extends TestCase
+{
+    public function testDoesNotEnqeueParents()
+    {
+        $url = Url::fromUrl('https://www.dantleech.com');
+
+        $queue = new FirstExternalOnlyQueue(new RealUrlQueue(), $url);
+
+        $internalUrl = $url->resolveUrl('https://www.dantleech.com/1234');
+        $externalUrl = $internalUrl->resolveUrl('https://foobar.com');
+        $externalUrlChild = $externalUrl->resolveUrl('https://foobar.com/test');
+
+        $queue->enqueue($internalUrl);
+        $this->assertCount(1, $queue);
+        $queue->enqueue($externalUrl);
+        $this->assertCount(2, $queue);
+
+        $queue->enqueue($externalUrlChild);
+        $this->assertCount(2, $queue);
+    }
+}


### PR DESCRIPTION
If you for example crawl https://example.org you want to know the status of a external url e.g https://test.com  but you don't want that test.com is also crawled.

Not sure if thats the correct place for the check another way would be create something like OnlyDescendantOrSelfQueue but checking for referer:

```diff
diff --git a/lib/Model/Queue/OnlyDescendantOrSelfQueue.php b/lib/Model/Queue/OnlyDescendantOrSelfQueue.php
index 75f6aea..a8f2cac 100644
--- a/lib/Model/Queue/OnlyDescendantOrSelfQueue.php
+++ b/lib/Model/Queue/OnlyDescendantOrSelfQueue.php
@@ -33,7 +33,7 @@ class OnlyDescendantOrSelfQueue implements UrlQueue

     public function enqueue(Url $url): void
     {
-        if (false === $url->equalsOrDescendantOf($this->baseUrl)) {
+        if (false === $url->referrer()->equalsOrDescendantOf($this->baseUrl)) {
             return;
         }

```