### PR TITLE
Document required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "php": "^7.1",
         "phpactor/container": "^1.0",
         "phpactor/console-extension": "~0.1",
         "amphp/artax": "^3.0",


### PR DESCRIPTION
This will give people using php <7.1 a bit more of a clear error message when installing with composer. And it is also a best practice.