### PR TITLE
Make EndToEndTestCase abstract

### DIFF
--- a/tests/EndToEnd/EndToEndTestCase.php
+++ b/tests/EndToEnd/EndToEndTestCase.php
@@ -7,7 +7,7 @@ use DTL\Extension\Fink\Tests\IntegrationTestCase;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
-class EndToEndTestCase extends IntegrationTestCase
+abstract class EndToEndTestCase extends IntegrationTestCase
 {
     protected function execute(array $args, string $project = 'website'): Process
     {


### PR DESCRIPTION
This class shouldn't be run as a test by itself.