### PR TITLE
Fix: Keep rules sorted in .php_cs.dist

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,8 +8,8 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
-        'no_unused_imports' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
This PR

* [x] keeps rules sorted in `.php_cs.dist`