### PR TITLE
Fix: Remove duplicate entry from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 /tests/Workspace
 /.phpactor.yml
 /.phpactor/*
-/.php_cs.cache
 /.phpunit.result.cache


### PR DESCRIPTION
This PR

* [x] removes a duplicate entry from `.gitignore`