### PR TITLE
Fix: Type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dantleech/fink",
     "description": "Checks Links",
     "license": "MIT",
-    "type": "lib",
+    "type": "library",
     "authors": [
         {
             "name": "Daniel Leech",


### PR DESCRIPTION
This {R

* [x] uses `library` instead of `lib` as package type