### PR TITLE
Specify poll interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Support for loading cookie files from netscape cookie files.
+- Support specifying the HTTP request interval with `--interval`
 
 ## [0.1.0] - 2019-01-20
 

--- a/lib/Command/CrawlCommand.php
+++ b/lib/Command/CrawlCommand.php
@@ -32,6 +32,7 @@ class CrawlCommand extends Command
     public const OPT_OUTPUT = 'output';
     public const OPT_INSECURE = 'insecure';
     public const OPT_LOAD_COOKIES = 'load-cookies';
+    public const OPT_REQUEST_INTERVAL = 'interval';
 
     /**
      * @var DispatcherBuilderFactory
@@ -57,6 +58,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_INSECURE, 'k', InputOption::VALUE_NONE, 'Allow insecure server connections with SSL');
         $this->addOption(self::OPT_MAX_DISTANCE, 'm', InputOption::VALUE_REQUIRED, 'Maximum link distance from base URL');
         $this->addOption(self::OPT_LOAD_COOKIES, null, InputOption::VALUE_REQUIRED, 'Load cookies from file');
+        $this->addOption(self::OPT_REQUEST_INTERVAL, null, InputOption::VALUE_REQUIRED, 'Dispatch request every n milliseconds', 10);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -64,8 +66,9 @@ class CrawlCommand extends Command
         assert($output instanceof ConsoleOutput);
 
         $dispatcher = $this->buildDispatcher($input);
+        $dispatcher->dispatch();
 
-        Loop::repeat(self::RUNNER_POLL_TIME, function () use ($dispatcher) {
+        Loop::repeat($this->castToInt($input->getOption(self::OPT_REQUEST_INTERVAL)), function () use ($dispatcher) {
             $dispatcher->dispatch();
         });
 

--- a/tests/EndToEnd/Command/CrawlCommandTest.php
+++ b/tests/EndToEnd/Command/CrawlCommandTest.php
@@ -14,7 +14,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertProcessSuccess($process);
     }
 
-    public function testCrawlsUrlPublishesReport()
+    public function testPublishesReport()
     {
         $process = $this->execute([
             'crawl',
@@ -33,7 +33,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertStatus($rows, 404, '404.html');
     }
 
-    public function testCrawlsDescendantsOnly()
+    public function testCrawlDescendantsOnly()
     {
         $process = $this->execute([
             'crawl',
@@ -70,7 +70,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertUrlCount($rows, 1, 'posts/post1.html');
     }
 
-    public function testAllowsTheConcurrencyToBeSet()
+    public function testConcurrencyCanBeSet()
     {
         $process = $this->execute([
             'crawl',
@@ -87,7 +87,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertUrlCount($rows, 1, 'about.html');
     }
 
-    public function testInsecure()
+    public function testDisableSslVerfication()
     {
         $process = $this->execute([
             'crawl',
@@ -98,7 +98,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertProcessSuccess($process);
     }
 
-    public function testMaxDisatance()
+    public function testSpecifyMaxDistanceFromTheBaseDocument()
     {
         $process = $this->execute([
             'crawl',
@@ -117,7 +117,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertUrlCount($rows, 0, 'posts/post2.html');
     }
 
-    public function testCookieProtectedPageWithNoCookie()
+    public function testCannotAccessCookieProtectedPageWithoutCookie()
     {
         $process = $this->execute([
             'crawl',
@@ -131,7 +131,7 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertStatus($rows, 403, 'cookie.php');
     }
 
-    public function testCookieProtectedPageWithCorrectCookies()
+    public function testCanAccessProtectedPageWithCookieAppropriateNetscapeCookieFile()
     {
         $process = $this->execute([
             'crawl',
@@ -147,7 +147,19 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertStatus($rows, 200, 'cookie.php');
     }
 
-    public function testExitIfCookieFileNotFound()
+    public function testSpecifyRequestPollInterval()
+    {
+        $process = $this->execute([
+            'crawl',
+            self::EXAMPLE_URL . '/',
+            '--interval=10',
+            '--output='.$this->workspace()->path('/out.json'),
+        ], 'website');
+
+        $this->assertProcessSuccess($process);
+    }
+
+    public function testExitsWithErrorIfCookieFileNotFound()
     {
         $process = $this->execute([
             'crawl',


### PR DESCRIPTION
Specifies the HTTP request\ interval.

Note that currentrly one request is made every _n_ milliseconds, instead of trying to dispatch the entire the queue with the availabile concurrency. In the future the semantics of this option may change.