### PR TITLE
Allow display to be customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 - Show referring link text and xpath #49
+- Allow display elements to be set, added or removed #54
 
 ## [0.6.0] 2019-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [unreleased]
 
-- Show referring link text and xpath #49
-- Allow display elements to be set, added or removed #54
+- Show referring link text and xpath #49.
+- Allow display elements to be set, added or removed #54,
+- Adds "uptime" display showing running time in hours, minutes and seconds.
 
 ## [0.6.0] 2019-03-14
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ Options
 - `--client-timeout=15000` Set the maximum amount of time (in milliseconds)
   the client should wait for a response, defaults to 15,000 (15 seconds).
 - `--concurrency`: Number of simultaneous HTTP requests to use.
-- `--display-bufsize=10` Set the number of URLs shown during execution.
+- `--display-bufsize=10` Set the number of URLs to consider when showing the
+  display.
+- `--display=+memory` Set, add or remove elements of the runtime display
+  (prefix with `-` or `+` to modify the default set).
 - `--exclude-url=logout` (multiple) Exclude URLs matching the given PCRE pattern.
 - `--header="Foo: Bar"` (multiple) Specify custom header(s).
 - `--include-link=foobar.html` Include given link as if it were linked from the

--- a/lib/Console/Command/CrawlCommand.php
+++ b/lib/Console/Command/CrawlCommand.php
@@ -3,7 +3,6 @@
 namespace DTL\Extension\Fink\Console\Command;
 
 use Amp\Loop;
-use DTL\Extension\Fink\Console\Display;
 use DTL\Extension\Fink\Console\DisplayBuilder;
 use DTL\Extension\Fink\Console\HeaderParser;
 use DTL\Extension\Fink\Model\DispatcherBuilderFactory;
@@ -103,6 +102,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_HEADER, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Custom header, e.g. "X-Teapot: Me"', []);
         $this->addOption(self::OPT_RATE, null, InputOption::VALUE_REQUIRED, 'Set max request rate (as requests per second)', []);
         $this->addOption(self::OPT_INCLUDE_LINK, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Add an additional URL to the set of URLs under the base URL', []);
+        $this->addOption('display', null, InputOption::VALUE_REQUIRED, 'Display specification, e.g. +memory', '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -117,7 +117,8 @@ class CrawlCommand extends Command
         });
 
         $section1 = $output->section();
-        $display = $this->displayBuilder->build('');
+
+        $display = $this->displayBuilder->build($this->castToString($input->getOption('display')));
 
         Loop::repeat(self::DISPLAY_POLL_TIME, function () use ($display, $section1, $dispatcher) {
             if (false === $this->shuttingDown) {

--- a/lib/Console/Command/CrawlCommand.php
+++ b/lib/Console/Command/CrawlCommand.php
@@ -102,7 +102,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_HEADER, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Custom header, e.g. "X-Teapot: Me"', []);
         $this->addOption(self::OPT_RATE, null, InputOption::VALUE_REQUIRED, 'Set max request rate (as requests per second)', []);
         $this->addOption(self::OPT_INCLUDE_LINK, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Add an additional URL to the set of URLs under the base URL', []);
-        $this->addOption('display', null, InputOption::VALUE_REQUIRED, 'Display specification, e.g. +memory', '');
+        $this->addOption('display', 'd', InputOption::VALUE_REQUIRED, 'Display specification, e.g. +memory', '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/lib/Console/Command/CrawlCommand.php
+++ b/lib/Console/Command/CrawlCommand.php
@@ -4,6 +4,7 @@ namespace DTL\Extension\Fink\Console\Command;
 
 use Amp\Loop;
 use DTL\Extension\Fink\Console\Display;
+use DTL\Extension\Fink\Console\DisplayBuilder;
 use DTL\Extension\Fink\Console\HeaderParser;
 use DTL\Extension\Fink\Model\DispatcherBuilderFactory;
 use DTL\Extension\Fink\Model\Dispatcher;
@@ -51,9 +52,9 @@ class CrawlCommand extends Command
     private $factory;
 
     /**
-     * @var Display
+     * @var DisplayBuilder
      */
-    private $display;
+    private $displayBuilder;
 
     /**
      * @var int
@@ -70,11 +71,11 @@ class CrawlCommand extends Command
      */
     private $headerParser;
 
-    public function __construct(DispatcherBuilderFactory $factory, Display $display)
+    public function __construct(DispatcherBuilderFactory $factory, DisplayBuilder $displayBuilder)
     {
         parent::__construct();
         $this->factory = $factory;
-        $this->display = $display;
+        $this->displayBuilder = $displayBuilder;
         $this->headerParser = new HeaderParser();
     }
 
@@ -116,10 +117,11 @@ class CrawlCommand extends Command
         });
 
         $section1 = $output->section();
+        $display = $this->displayBuilder->build('');
 
-        Loop::repeat(self::DISPLAY_POLL_TIME, function () use ($section1, $dispatcher) {
+        Loop::repeat(self::DISPLAY_POLL_TIME, function () use ($display, $section1, $dispatcher) {
             if (false === $this->shuttingDown) {
-                $section1->overwrite($this->display->render($section1->getFormatter(), $dispatcher->status()));
+                $section1->overwrite($display->render($section1->getFormatter(), $dispatcher->status()));
             }
 
             $status = $dispatcher->status();

--- a/lib/Console/Command/CrawlCommand.php
+++ b/lib/Console/Command/CrawlCommand.php
@@ -44,6 +44,7 @@ class CrawlCommand extends Command
     private const OPT_INCLUDE_LINK = 'include-link';
     private const OPT_CLIENT_MAX_HEADER_SIZE = 'client-max-header-size';
     private const OPT_CLIENT_MAX_BODY_SIZE = 'client-max-body-size';
+    private const OPT_DISPLAY = 'display';
 
     /**
      * @var DispatcherBuilderFactory
@@ -102,7 +103,7 @@ class CrawlCommand extends Command
         $this->addOption(self::OPT_HEADER, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Custom header, e.g. "X-Teapot: Me"', []);
         $this->addOption(self::OPT_RATE, null, InputOption::VALUE_REQUIRED, 'Set max request rate (as requests per second)', []);
         $this->addOption(self::OPT_INCLUDE_LINK, null, InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Add an additional URL to the set of URLs under the base URL', []);
-        $this->addOption('display', 'd', InputOption::VALUE_REQUIRED, 'Display specification, e.g. +memory', '');
+        $this->addOption(self::OPT_DISPLAY, 'd', InputOption::VALUE_REQUIRED, 'Display specification, e.g. +memory', '');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -118,7 +119,7 @@ class CrawlCommand extends Command
 
         $section1 = $output->section();
 
-        $display = $this->displayBuilder->build($this->castToString($input->getOption('display')));
+        $display = $this->displayBuilder->build($this->castToString($input->getOption(self::OPT_DISPLAY)));
 
         Loop::repeat(self::DISPLAY_POLL_TIME, function () use ($display, $section1, $dispatcher) {
             if (false === $this->shuttingDown) {

--- a/lib/Console/Display/RateDisplay.php
+++ b/lib/Console/Display/RateDisplay.php
@@ -38,8 +38,7 @@ class RateDisplay implements Display
         $averageRequestTime = $this->averageRequestTime($status->reportStore());
 
         return sprintf(
-            '<info>Up</> %s <info>sec</>, %s <info>r/sec</>, %s<info> ms/r</>',
-            number_format(microtime(true) - $this->initialTime, 1),
+            '<info>Rate</>: %s <info>r/sec</>, %s<info> ms/r</>',
             number_format($ratePerSecond, 2),
             number_format($averageRequestTime * 0.001, 2)
         );

--- a/lib/Console/Display/UptimeDisplay.php
+++ b/lib/Console/Display/UptimeDisplay.php
@@ -3,13 +3,9 @@
 namespace DTL\Extension\Fink\Console\Display;
 
 use DTL\Extension\Fink\Console\Display;
-use DTL\Extension\Fink\Model\Report;
 use DTL\Extension\Fink\Model\Status;
-use DTL\Extension\Fink\Model\Store\ImmutableReportStore;
 use DateInterval;
 use DateTimeImmutable;
-use Khill\Duration\Duration;
-use RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 class UptimeDisplay implements Display
@@ -45,7 +41,7 @@ class UptimeDisplay implements Display
             '%02dh %02dm %02ds',
             $interval->h,
             $interval->i,
-            $interval->s,
+            $interval->s
         );
     }
 }

--- a/lib/Console/Display/UptimeDisplay.php
+++ b/lib/Console/Display/UptimeDisplay.php
@@ -34,7 +34,7 @@ class UptimeDisplay implements Display
         $interval = $this->initialTime->diff(new DateTimeImmutable());
 
         return sprintf(
-            '<info>Up</> %s',
+            '<info>Uptime:</> %s',
             $this->formatDuration($interval)
         );
     }

--- a/lib/Console/Display/UptimeDisplay.php
+++ b/lib/Console/Display/UptimeDisplay.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DTL\Extension\Fink\Console\Display;
+
+use DTL\Extension\Fink\Console\Display;
+use DTL\Extension\Fink\Model\Report;
+use DTL\Extension\Fink\Model\Status;
+use DTL\Extension\Fink\Model\Store\ImmutableReportStore;
+use DateInterval;
+use DateTimeImmutable;
+use Khill\Duration\Duration;
+use RuntimeException;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
+class UptimeDisplay implements Display
+{
+    /**
+     * @var DateTimeImmutable
+     */
+    private $initialTime;
+
+    /**
+     * @var int
+     */
+    private $windowSize;
+
+    public function __construct(?DateTimeImmutable $initialTime = null)
+    {
+        $this->initialTime = $initialTime ?: new DateTimeImmutable();
+    }
+
+    public function render(OutputFormatterInterface $output, Status $status): string
+    {
+        $interval = $this->initialTime->diff(new DateTimeImmutable());
+
+        return sprintf(
+            '<info>Up</> %s',
+            $this->formatDuration($interval)
+        );
+    }
+
+    private function formatDuration(DateInterval $interval): string
+    {
+        return sprintf(
+            '%02dh %02dm %02ds',
+            $interval->h,
+            $interval->i,
+            $interval->s,
+        );
+    }
+}

--- a/lib/Console/DisplayBuilder.php
+++ b/lib/Console/DisplayBuilder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DTL\Extension\Fink\Console;
+
+use DTL\Extension\Fink\Console\Display\ConcatenatingDisplay;
+
+class DisplayBuilder
+{
+    /**
+     * @var DisplayRegistry
+     */
+    private $registry;
+
+    /**
+     * @var array
+     */
+    private $default;
+
+    public function __construct(DisplayRegistry $registry, array $defaut = [])
+    {
+        $this->registry = $registry;
+        $this->default = $defaut;
+    }
+
+    public function build(string $spec): Display
+    {
+        $units = array_filter(array_map('strtolower', array_map('trim', explode(',', $spec))));
+
+        $units = $this->initializeDisplayNames($units);
+        $units = $this->removeDisplayNames($units);
+
+        $displays = [];
+        foreach ($units as $unit) {
+            if (substr($unit, 0, 1) === '+') {
+                $displays[] = $this->registry->get(substr($unit, 1));
+                continue;
+            }
+
+            $displays[] = $this->registry->get($unit);
+        }
+
+        return new ConcatenatingDisplay($displays);
+    }
+
+    private function initializeDisplayNames(array $units): array
+    {
+        $reset = array_reduce($units, function (bool $reset, string $unit) {
+            if ($reset === true) {
+                return $reset;
+            }
+            $prefix = substr($unit, 0, 1);
+            return false === in_array($prefix, ['+','-']);
+        }, false);
+        
+        if (!$reset) {
+            $units = array_merge($this->default, $units);
+        }
+        return $units;
+    }
+
+    private function removeDisplayNames(array $units): array
+    {
+        $remove = array_filter(array_map(function (string $unit) {
+            if (substr($unit, 0, 1) === '-') {
+                return substr($unit, 1);
+            }
+        
+            return null;
+        }, $units));
+        
+        $units = array_filter($units, function (string $unit) use ($remove) {
+            if (in_array($unit, $remove)) {
+                return false;
+            }
+
+            if (substr($unit, 0, 1) === '-') {
+                return false;
+            }
+
+            return true;
+        });
+        return $units;
+    }
+}

--- a/lib/Console/DisplayRegistry.php
+++ b/lib/Console/DisplayRegistry.php
@@ -23,7 +23,8 @@ class DisplayRegistry
         if (!isset($this->displays[$name])) {
             throw new DisplayNotFound(sprintf(
                 'Display "%s" not found, known displays "%s"',
-                $name, implode('", "', array_keys($this->displays))
+                $name,
+                implode('", "', array_keys($this->displays))
             ));
         }
 

--- a/lib/Console/DisplayRegistry.php
+++ b/lib/Console/DisplayRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DTL\Extension\Fink\Console;
+
+use DTL\Extension\Fink\Console\Exception\DisplayNotFound;
+
+class DisplayRegistry
+{
+    /**
+     * @var array
+     */
+    private $displays = [];
+
+    public function __construct(array $displays = [])
+    {
+        foreach ($displays as $name => $display) {
+            $this->add($name, $display);
+        }
+    }
+
+    public function get(string $name)
+    {
+        if (!isset($this->displays[$name])) {
+            throw new DisplayNotFound(sprintf(
+                'Display "%s" not found, known displays "%s"',
+                $name, implode('", "', array_keys($this->displays))
+            ));
+        }
+
+        return $this->displays[$name];
+    }
+
+    private function add(string $name, Display $display)
+    {
+        $this->displays[$name] = $display;
+    }
+}

--- a/lib/Console/Exception/DisplayNotFound.php
+++ b/lib/Console/Exception/DisplayNotFound.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DTL\Extension\Fink\Console\Exception;
+
+use RuntimeException;
+
+class DisplayNotFound extends RuntimeException
+{
+}

--- a/lib/FinkExtension.php
+++ b/lib/FinkExtension.php
@@ -35,7 +35,7 @@ class FinkExtension implements Extension
 
         $container->register('fink.console.display_registry', function (Container $container) {
             return new DisplayRegistry([
-                'url_list' => new ReportListDisplay(),
+                'urllist' => new ReportListDisplay(),
                 'status' => new StatusLineDisplay(),
                 'rate' => new RateDisplay(),
                 'memory' => new MemoryDisplay(),
@@ -45,7 +45,7 @@ class FinkExtension implements Extension
 
         $container->register('fink.console.display_builder', function (Container $container) {
             return new DisplayBuilder($container->get('fink.console.display_registry'), [
-                'url_list', 'status', 'rate', 'uptime'
+                'urllist', 'status', 'rate', 'uptime'
             ]);
         });
 

--- a/lib/FinkExtension.php
+++ b/lib/FinkExtension.php
@@ -9,6 +9,7 @@ use DTL\Extension\Fink\Console\Display\MemoryDisplay;
 use DTL\Extension\Fink\Console\Display\RateDisplay;
 use DTL\Extension\Fink\Console\Display\StatusLineDisplay;
 use DTL\Extension\Fink\Console\Display\ReportListDisplay;
+use DTL\Extension\Fink\Console\Display\UptimeDisplay;
 use DTL\Extension\Fink\Model\DispatcherBuilderFactory;
 use Phpactor\Container\Container;
 use Phpactor\Container\ContainerBuilder;
@@ -37,7 +38,8 @@ class FinkExtension implements Extension
                 'url_list' => new ReportListDisplay(),
                 'status' => new StatusLineDisplay(),
                 'rate' => new RateDisplay(),
-                'memory' => new MemoryDisplay()
+                'memory' => new MemoryDisplay(),
+                'uptime' => new UptimeDisplay(),
             ]);
         });
 

--- a/lib/FinkExtension.php
+++ b/lib/FinkExtension.php
@@ -45,7 +45,7 @@ class FinkExtension implements Extension
 
         $container->register('fink.console.display_builder', function (Container $container) {
             return new DisplayBuilder($container->get('fink.console.display_registry'), [
-                'url_list', 'status', 'rate'
+                'url_list', 'status', 'rate', 'uptime'
             ]);
         });
 

--- a/lib/FinkExtension.php
+++ b/lib/FinkExtension.php
@@ -5,7 +5,6 @@ namespace DTL\Extension\Fink;
 use DTL\Extension\Fink\Console\Command\CrawlCommand;
 use DTL\Extension\Fink\Console\DisplayBuilder;
 use DTL\Extension\Fink\Console\DisplayRegistry;
-use DTL\Extension\Fink\Console\Display\ConcatenatingDisplay;
 use DTL\Extension\Fink\Console\Display\MemoryDisplay;
 use DTL\Extension\Fink\Console\Display\RateDisplay;
 use DTL\Extension\Fink\Console\Display\StatusLineDisplay;

--- a/lib/FinkExtension.php
+++ b/lib/FinkExtension.php
@@ -3,7 +3,10 @@
 namespace DTL\Extension\Fink;
 
 use DTL\Extension\Fink\Console\Command\CrawlCommand;
+use DTL\Extension\Fink\Console\DisplayBuilder;
+use DTL\Extension\Fink\Console\DisplayRegistry;
 use DTL\Extension\Fink\Console\Display\ConcatenatingDisplay;
+use DTL\Extension\Fink\Console\Display\MemoryDisplay;
 use DTL\Extension\Fink\Console\Display\RateDisplay;
 use DTL\Extension\Fink\Console\Display\StatusLineDisplay;
 use DTL\Extension\Fink\Console\Display\ReportListDisplay;
@@ -26,15 +29,22 @@ class FinkExtension implements Extension
         $container->register('fink.console.command.crawl', function (Container $container) {
             return new CrawlCommand(
                 $container->get(self::SERVICE_DISPATCHER_BUILDER_FACTORY),
-                $container->get('fink.console.display')
+                $container->get('fink.console.display_builder')
             );
         }, [ ConsoleExtension::TAG_COMMAND => [ 'name' => 'crawl' ]]);
 
-        $container->register('fink.console.display', function (Container $container) {
-            return new ConcatenatingDisplay([
-                new ReportListDisplay(),
-                new StatusLineDisplay(),
-                new RateDisplay(),
+        $container->register('fink.console.display_registry', function (Container $container) {
+            return new DisplayRegistry([
+                'url_list' => new ReportListDisplay(),
+                'status' => new StatusLineDisplay(),
+                'rate' => new RateDisplay(),
+                'memory' => new MemoryDisplay()
+            ]);
+        });
+
+        $container->register('fink.console.display_builder', function (Container $container) {
+            return new DisplayBuilder($container->get('fink.console.display_registry'), [
+                'url_list', 'status', 'rate'
             ]);
         });
 

--- a/tests/EndToEnd/Command/CrawlCommandTest.php
+++ b/tests/EndToEnd/Command/CrawlCommandTest.php
@@ -350,6 +350,15 @@ class CrawlCommandTest extends EndToEndTestCase
         $this->assertEquals('/html/body/ul/li[1]/a', $url['referrer_xpath']);
     }
 
+    public function testAllowsDisplayCustomization()
+    {
+        $process = $this->execute([
+            self::EXAMPLE_URL,
+            '--display=status'
+        ]);
+        $this->assertProcessSuccess($process);
+    }
+
     private function assertStatus(array $results, int $code, string $target): void
     {
         $target = self::EXAMPLE_URL . '/'. $target;

--- a/tests/Unit/Console/Display/RateDisplayTest.php
+++ b/tests/Unit/Console/Display/RateDisplayTest.php
@@ -15,7 +15,7 @@ class RateDisplayTest extends DisplayTestCase
         $output = $display->render($this->formatter, new Status());
 
         $this->assertContains(<<<'EOT'
-Up 0.0 sec, 0.00 r/sec
+Rate: 0.00 r/sec
 EOT
         , FormatterHelper::removeDecoration($this->formatter, $output));
     }
@@ -26,7 +26,7 @@ EOT
         $output = $display->render($this->formatter, new Status());
 
         $this->assertContains(<<<'EOT'
-Up 1.0 sec, 0.00 r/sec
+Rate: 0.00 r/sec
 EOT
         , FormatterHelper::removeDecoration($this->formatter, $output));
     }
@@ -41,7 +41,7 @@ EOT
         $output = $display->render($this->formatter, new Status());
 
         $this->assertContains(<<<'EOT'
-Up 1.0 sec, 1.00 r/sec
+Rate: 1.00 r/sec
 EOT
         , FormatterHelper::removeDecoration($this->formatter, $output));
     }
@@ -57,7 +57,7 @@ EOT
         $output = $display->render($this->formatter, new Status());
 
         $this->assertContains(<<<'EOT'
-Up 5.0 sec, 0.25 r/sec
+Rate: 0.25 r/sec
 EOT
         , FormatterHelper::removeDecoration($this->formatter, $output));
     }

--- a/tests/Unit/Console/Display/UptimeDisplayTest.php
+++ b/tests/Unit/Console/Display/UptimeDisplayTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DTL\Extension\Fink\Tests\Unit\Console\Display;
+
+use DTL\Extension\Fink\Console\Display\UptimeDisplay;
+use DTL\Extension\Fink\Model\Status;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\FormatterHelper;
+
+class UptimeDisplayTest extends DisplayTestCase
+{
+    /**
+     * @dataProvider provideShowsUptime
+     */
+    public function testShowsUptime($uptime, $expected)
+    {
+        $uptime = new UptimeDisplay((new DateTimeImmutable())->modify('-' . $uptime . ' seconds'));
+        $status = $uptime->render($this->formatter, new Status());
+        $this->assertEquals($expected, FormatterHelper::removeDecoration($this->formatter, $status));
+    }
+
+    public function provideShowsUptime()
+    {
+        yield [
+            1, 'Up 00h 00m 01s',
+        ];
+
+        yield [
+            60, 'Up 00h 01m 00s',
+        ];
+
+        yield [
+            3600, 'Up 01h 00m 00s',
+        ];
+    }
+}

--- a/tests/Unit/Console/Display/UptimeDisplayTest.php
+++ b/tests/Unit/Console/Display/UptimeDisplayTest.php
@@ -23,15 +23,15 @@ class UptimeDisplayTest extends DisplayTestCase
     public function provideShowsUptime()
     {
         yield [
-            1, 'Up 00h 00m 01s',
+            1, 'Uptime: 00h 00m 01s',
         ];
 
         yield [
-            60, 'Up 00h 01m 00s',
+            60, 'Uptime: 00h 01m 00s',
         ];
 
         yield [
-            3600, 'Up 01h 00m 00s',
+            3600, 'Uptime: 01h 00m 00s',
         ];
     }
 }

--- a/tests/Unit/Console/Display/UptimeDisplayTest.php
+++ b/tests/Unit/Console/Display/UptimeDisplayTest.php
@@ -5,7 +5,6 @@ namespace DTL\Extension\Fink\Tests\Unit\Console\Display;
 use DTL\Extension\Fink\Console\Display\UptimeDisplay;
 use DTL\Extension\Fink\Model\Status;
 use DateTimeImmutable;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\FormatterHelper;
 
 class UptimeDisplayTest extends DisplayTestCase

--- a/tests/Unit/Console/DisplayBuilderTest.php
+++ b/tests/Unit/Console/DisplayBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace DTL\Extension\Fink\Tests\Unit\Console;
+
+use DTL\Extension\Fink\Console\Display;
+use DTL\Extension\Fink\Console\DisplayBuilder;
+use DTL\Extension\Fink\Console\DisplayRegistry;
+use DTL\Extension\Fink\Console\Display\ConcatenatingDisplay;
+use PHPUnit\Framework\TestCase;
+
+class DisplayBuilderTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy
+     */
+    private $registry;
+    /**
+     * @var ObjectProphecy
+     */
+    private $display1;
+    /**
+     * @var ObjectProphecy
+     */
+    private $display2;
+
+    /**
+     * @var DisplayBuilder
+     */
+    private $builder;
+
+    public function setUp()
+    {
+        $this->registry = $this->prophesize(DisplayRegistry::class);
+        $this->display1 = $this->prophesize(Display::class);
+        $this->display2 = $this->prophesize(Display::class);
+    }
+
+    public function testSetsADisplay()
+    {
+        $this->registry->get('foo')->willReturn($this->display1->reveal());
+
+        $display = $this->createBuilder(['bar'])->build('foo');
+        $this->assertEquals(new ConcatenatingDisplay([
+            $this->display1->reveal()
+        ]), $display);
+    }
+
+    public function testConcatenatesMultipleDisplays()
+    {
+        $this->registry->get('foo')->willReturn($this->display1->reveal());
+        $this->registry->get('bar')->willReturn($this->display2->reveal());
+
+        $display = $this->createBuilder()->build('foo');
+        $this->assertEquals(new ConcatenatingDisplay([
+            $this->display1->reveal()
+        ]), $display);
+    }
+
+    public function testAddsDisplayWithPlusPrefix()
+    {
+        $this->registry->get('foo')->willReturn($this->display1->reveal());
+        $this->registry->get('bar')->willReturn($this->display2->reveal());
+
+        $display = $this->createBuilder(['foo'])->build('+bar');
+        $this->assertEquals(new ConcatenatingDisplay([
+            $this->display1->reveal(),
+            $this->display2->reveal()
+        ]), $display);
+    }
+
+    public function testRemovesADisplayWithAMinusPrefix()
+    {
+        $this->registry->get('foo')->willReturn($this->display1->reveal());
+        $this->registry->get('bar')->willReturn($this->display2->reveal());
+
+        $display = $this->createBuilder(['foo', 'bar'])->build('-bar');
+        $this->assertEquals(new ConcatenatingDisplay([
+            $this->display1->reveal()
+        ]), $display);
+    }
+
+    private function createBuilder(array $defaults = []): DisplayBuilder
+    {
+        return new DisplayBuilder($this->registry->reveal(), $defaults);
+    }
+}

--- a/tests/Unit/Console/DisplayRegistryTest.php
+++ b/tests/Unit/Console/DisplayRegistryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DTL\Extension\Fink\Tests\Unit\Console;
+
+use DTL\Extension\Fink\Console\Display;
+use DTL\Extension\Fink\Console\DisplayRegistry;
+use DTL\Extension\Fink\Console\Exception\DisplayNotFound;
+use PHPUnit\Framework\TestCase;
+
+class DisplayRegistryTest extends TestCase
+{
+    public function testItThrowsExceptionIfDisplayNodeFound()
+    {
+        $this->expectException(DisplayNotFound::class);
+        $this->createRegistry()->get('foo');
+    }
+
+    public function testItReturnsRegisteredDisplays()
+    {
+        $expected = $this->prophesize(Display::class)->reveal();
+        $display = $this->createRegistry([
+            'one' => $expected
+        ])->get('one');
+
+        $this->assertSame($expected, $display);
+    }
+
+    private function createRegistry(array $displays = []): DisplayRegistry
+    {
+        return new DisplayRegistry($displays);
+    }
+}


### PR DESCRIPTION
Allow the display to be customized:

With `--display=<spec>`:

- `+memory`: Show the memory.
- `-urllist` Do not show the URL list.
- `status` Only show the status display.
- `status,memory` Only show the status display and the memory usage.