### PR TITLE
Require minimum v1.2.2 for amphp/dns due to k8s dns issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
+        "amphp/dns": "^v1.2.2",
+        "amphp/file": "^1",
         "amphp/http-client": "^4.1.0",
         "amphp/http-client-cookies": "^1",
-        "amphp/file": "^1",
         "league/uri": "^6",
         "phpactor/console-extension": "~0.1",
         "phpactor/container": "^1.0",


### PR DESCRIPTION
This addresses the problem described on this issue: https://github.com/dantleech/fink/issues/115