### PR TITLE
Removing PHP 8.1 warnings

### DIFF
--- a/lib/Model/Store/CircularReportStore.php
+++ b/lib/Model/Store/CircularReportStore.php
@@ -36,6 +36,7 @@ final class CircularReportStore implements ReportStore
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->reports);

--- a/lib/Model/Urls.php
+++ b/lib/Model/Urls.php
@@ -34,6 +34,7 @@ class Urls implements IteratorAggregate
     /**
      * {@inheritDoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->urls);


### PR DESCRIPTION
To resolve some PHP 8.1 warnings as seen in issue #123 
This is not totally solving the issue but removing the warnings until a fully compatible php 8.1 version is created with possible thinking about backwards compatibility. 