### PR TITLE
Support parsing httponly cookies

### DIFF
--- a/lib/Adapter/Artax/NetscapeCookieFileJar.php
+++ b/lib/Adapter/Artax/NetscapeCookieFileJar.php
@@ -69,7 +69,14 @@ class NetscapeCookieFileJar implements CookieJar
             return null;
         }
 
-        if ($line[0] === '#') {
+        // Handle httponly cookies - lines starting with #HttpOnly_ should be parsed
+        // See: https://curl.se/docs/http-cookies.html
+        $isHttpOnly = false;
+        if (str_starts_with($line, '#HttpOnly_')) {
+            $line = substr($line, 10); // Remove the '#HttpOnly_' prefix
+            $isHttpOnly = true;
+        } elseif ($line[0] === '#') {
+            // Regular comment line, skip it
             return null;
         }
 
@@ -102,6 +109,10 @@ class NetscapeCookieFileJar implements CookieJar
         \assert($secure !== null); // silence phpstan
         if (strtolower($secure) === 'true') {
             $string .= '; secure';
+        }
+
+        if ($isHttpOnly) {
+            $string .= '; httponly';
         }
 
         return ResponseCookie::fromHeader($string);

--- a/tests/Integration/Adapter/Artax/NetscapeCookieFileJarTest.php
+++ b/tests/Integration/Adapter/Artax/NetscapeCookieFileJarTest.php
@@ -71,4 +71,41 @@ EOT
             (yield $jar->get((new Request('http://127.0.0.1/'))->getUri()))[0]->getValue()
         );
     }
+
+    public function testLoadHttpOnlyCookies()
+    {
+        $expire = (new DateTimeImmutable())->modify('+1 day')->format('U');
+
+        $cookies = <<<EOT
+# Netscape HTTP Cookie File
+# This is a comment and should be ignored
+
+#HttpOnly_.example.com	TRUE	/	FALSE	$expire	session_id	abc123
+#HttpOnly_example.com	FALSE	/admin	TRUE	$expire	admin_token	xyz789
+.example.com	TRUE	/	FALSE	$expire	regular_cookie	normal_value
+EOT
+        ;
+
+        $path = $this->workspace()->path('httponly_cookies.txt');
+        file_put_contents($path, $cookies);
+
+        $jar = new NetscapeCookieFileJar($path);
+
+        $allCookies = $jar->getAll();
+
+        // Should have 3 cookies total (2 httponly + 1 regular)
+        $this->assertCount(3, $allCookies);
+
+        // Get cookies for example.com
+        $exampleCookies = yield $jar->get((new Request('https://example.com/'))->getUri());
+
+        // Should include the httponly cookie
+        $cookieNames = array_map(fn ($cookie) => $cookie->getName(), $exampleCookies);
+        $this->assertContains('session_id', $cookieNames);
+        $this->assertContains('regular_cookie', $cookieNames);
+
+        // Verify httponly cookie value
+        $sessionCookie = array_filter($exampleCookies, fn ($cookie) => $cookie->getName() === 'session_id');
+        $this->assertEquals('abc123', reset($sessionCookie)->getValue());
+    }
 }

--- a/tests/Integration/Adapter/Artax/NetscapeCookieFileJarTest.php
+++ b/tests/Integration/Adapter/Artax/NetscapeCookieFileJarTest.php
@@ -86,8 +86,8 @@ EOT
 EOT
         ;
 
+        $this->workspace()->put('httponly_cookies.txt', $cookies);
         $path = $this->workspace()->path('httponly_cookies.txt');
-        file_put_contents($path, $cookies);
 
         $jar = new NetscapeCookieFileJar($path);
 


### PR DESCRIPTION
Fixes #133

Adds support for parsing cookies with `#HttpOnly_` prefix according to the Netscape cookie file format specification.

See: https://curl.se/docs/http-cookies.html